### PR TITLE
move-navigation-from-left-to-top

### DIFF
--- a/app/views/Sprint_25_V6.html
+++ b/app/views/Sprint_25_V6.html
@@ -1,0 +1,975 @@
+<!DOCTYPE html>
+{% extends "layout_unbranded.html" %}
+{% from "checkboxes/macro.njk" import govukCheckboxes %}
+{% block pageTitle %} View my applications
+{% endblock %}
+{% block content %}
+
+<style>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8",chrome=1">
+  <meta name="HandheldFriendly" content="true">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+  <meta name="apple-mobile-web-app-capable" content="yes"/>
+
+  #submenu {
+    cursor: pointer;
+    color: #516715
+  }
+
+
+  /* Style the button that is used to open and close the collapsible content */
+  .collapsible {
+    color: #516715;
+    background-color: transparent;
+    cursor: pointer;
+    height: 30px;
+    border: none;
+    text-align: left;
+    outline: none;
+    font-size: 14px;
+    display: flex;
+    justify-content: left;
+    align-items: left;
+    width: 200px;
+  }
+
+  /* Add a background color to the button if it is clicked on (add the .active class with JS), and when you move the mouse over it (hover) */
+  .collapsible:hover {
+    background-color: #000000;
+    background-color: #D4E039;
+    color: black;
+  }
+
+  /* Style the collapsible content. Note: hidden by default */
+  .content {
+    padding-left: 10px;
+    font-size: 12px;
+    display: none;
+    overflow: hidden;
+    font-family: arial;
+    cursor: pointer;
+  }
+
+  .item {
+    width: 190px;
+    padding-top: 1px;
+    padding-bottom: 1px;
+    margin-bottom: 5px;
+    margin-top: 5px;
+  }
+
+  .item:hover {
+      background: #E5EC89;
+  }
+
+  .link:hover {
+    background: #E5EC89;
+    text-decoration: underline;
+  }
+
+  .footer-link {
+    color: #747576;
+    width: 100%;
+
+  }
+
+  .footlink-no:hover {
+    color: grey;
+  }
+
+  .footlink:hover {
+    color: #000000;
+    cursor: pointer;
+  }
+
+  .govuk-checkboxes__label {
+    font-size: 19px;
+    font-size: 1.1875rem;
+    line-height: 1.31579;
+  }
+
+  .govuk-checkboxes__item {
+    clear: unset;
+    width:40%;
+    float: left;
+  }
+
+  .govuk-table  {
+        box-sizing: border-box;
+        position: relative;
+        border-width: 1px;
+      }
+
+      .expandy-row {
+        box-sizing: border-box;
+        border-width: 1px;
+      }
+
+      .my-work {
+    font-size: unset;
+}
+
+
+ul.horizontal {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+    background-color: #f8f8f8;
+}
+
+ul.horizontal li {
+    float: left;
+}
+
+ul.horizontal li a.active {
+    background-color: #005ea5;
+    color:#ffffff;
+}
+ul.horizontal li a {
+    display: inline-block;
+    color: #005ea5;
+    text-align: center;
+    text-decoration: none;
+    font-weight: 700;
+    position: relative;
+    height: 50px;
+    padding: 0 15px;
+    line-height: 50px;
+}
+
+ul.horizontal li a:hover {
+  background-color: #005ea5;
+    color:#ffffff;
+}
+
+.rightli {
+    float: right!Important;
+}
+
+
+
+
+.my-work tbody td {
+    max-width: 150px;
+}
+
+
+
+.expandy-row-trigger2 {
+    width: 100%;
+    margin: auto;
+    text-align: center;
+    display: block;
+}
+
+.govuk-table__header, .govuk-table__cell {
+
+}
+
+
+
+</style>
+
+
+
+  <div class="govuk-grid-row">
+  <div class="govuk-grid-column-full" id="headerdiv">
+    <a href="portalhomepage.html"><img src="public/images/headerlogo.svg" alt="hmlrlogo"></a>
+    <br>
+    <a class="tooltip" href="#" style="float: right; font-size: 14px; font-weight: ; text-decoration: none; margin-top: 0px; margin-top :-15px;"> Customer Support <img style="float: right; font-size: 14px; margin-right: -5px; margin-top :-8px;" src="public/images/popout-modern.png" width="30" height="30">
+    <!-- <span class="tooltiptext">Opens in a new window</span></a> -->
+    <a href="#" style="float: right; font-size: 14px; font-weight: ; text-decoration: none; margin-right: 5px; padding-right: 10px; margin-top: -15px;"> Logout </a>
+    <hr style= "    height: 4px; background-image: linear-gradient(-60deg,#b4d307,#b4d307 50%,#d7e900 0,#d7e900);
+    border: none;">
+  </div>
+  </div>
+
+
+<div> 
+  <nav class="">
+    <ul class="horizontal">
+      
+      <li>
+        <a href="#" data-topnav="Styles">My Portal</a>
+      </li>
+
+      <li>
+        <a href="#" data-topnav="Styles">Documents</a>
+      </li>
+
+      <li>
+        <a class="active" href="#" data-topnav="Get started">Applications</a>
+      </li>
+
+      <li>
+        <a href="#" data-topnav="Get started">Search for information</a>
+      </li>
+     
+      <li>
+        <a href="#" data-topnav="Styles">Pre-completion</a>
+      </li>
+      
+      <li>
+        <a href="#" data-topnav="Components">E-services</a>
+      </li>
+      
+      <li class="rightli">
+        <a href="/help.html" data-topnav="Community">Help</a>
+      </li>
+      
+    </ul>
+  </nav>
+</div>
+
+<div class="govuk-grid-column-full" style="padding: 50px 0px 0px 0px;">
+    <h1 class="govuk-heading-l govuk-!-font-size-27" style=""> View My Applications </h1>
+
+
+
+    <!-- <div class="govuk-grid-column-one-half" style="float: right; margin-top: 80px; margin-left: 0px; padding:0px;">
+    <h2 class="govuk-body govuk-!-font-size-14" style="font-weight: normal; margin-top: -40px; margin-left: 16px; padding: 0px; margin-bottom: 0px;">Search by customer reference, title number or HMLR reference</h2>
+    <input type="text" id="search-input" style="width: 367px; margin-left: 16px; height: 36px; font-size: 14px; border-color: black; border-width: 1px; border-radius: 0px; margin-top: 0px;"><button style="float: right; margin-right: -35px; margin-top: 0px; cursor: pointer; border-radius: 0px" value="submit" id="search-button"> Search </button>
+    <a href="#" id="reset" class="govuk-link govuk-link--no-visited-state" style="float: right; font-size: 14px; margin-right: -35px; margin-top: -10px; padding-bottom: 30px"><br><u> Reset search</u></a>
+    </div> -->
+
+    <!--Filters & searches-->
+<!-- <style>
+.govuk-details__summary::before {
+margin-top: 6px;
+}
+</style> -->
+    <div>
+
+        <div class="govuk-grid-row" style="padding:0px 0px 30px 0px;">
+          <form id="search" style="">
+
+          <div class="govuk-grid-column-one-quarter" style="padding-top:16px;">
+                    <details class="govuk-details" data-module="govuk-details">
+                    <summary class="govuk-details__summary" style="">
+
+                      Filter by application type
+                    </summary>
+                    <div class="govuk-details-text">
+
+                      {{ govukCheckboxes ({
+                      idPrefix: "application-type2",
+                      name: "application-type2",
+                      classes: "govuk-checkboxes--small checkbox2",
+                      fieldset: {
+                        legend: {
+                          text: ""
+                        }
+                      },
+                      items: [
+                      {
+                        value: "Preliminary",
+                        text: "Register update",
+                        checked: false,
+                        id: "Preliminary"
+                      },
+
+                      {
+                        value: "Substantive",
+                        text: "Register create"   ,
+                          checked: false,
+                        id: "Substantive"
+                      },
+
+                      {
+                        value: "Sobstantive",
+                        text: "Register query"   ,
+                          checked: false,
+                        id: "Sobstantive"
+                      }
+                      ]
+                    }) }}
+
+                  </div>
+                </details>
+                </div>
+
+                  <div class="govuk-grid-column-one-quarter" style="padding-top:16px;">
+
+                    <details class="govuk-details" data-module="govuk-details">
+                    <summary class="govuk-details__summary">
+
+                      Filter by application progress
+                    </summary>
+                    <div class="govuk-details-text">
+
+                      {{ govukCheckboxes ({
+                      idPrefix: "application-progress2",
+                      name: "application-progress2",
+                      classes: "govuk-checkboxes--small checkbox3",
+                      fieldset: {
+                      legend: {
+                        text: ""
+                      }
+                      },
+                      items: [
+
+                      {
+                      value: "Received",
+                      text: "Received"   ,
+                      checked: false,
+                      id: "Received"
+                      },
+                      {
+                      value: "Cancelled",
+                      text: "Cancelled"   ,
+                        checked: false,
+                      id: "Cancelled"
+                      },
+                      {
+                      value: "Delayed",
+                      text: "Delayed"   ,
+                        checked: false,
+                      id: "Delayed"
+                      },
+                      {
+                      value: "Completed",
+                      text: "Completed"   ,
+                        checked: false,
+                      id: "Completed"
+                      }
+                      ]
+                      }) }}
+                    </div>
+                  </details>
+                </div>
+
+
+    <div class="govuk-grid-column-one-half" style="float: right;">
+        <h2 class="govuk-body govuk-!-font-size-14" style="text-align:right; margin-bottom: 10px;">Search by customer reference, title number or HMLR reference</h2>
+        
+    <div style="float:right;">
+        <input type="text" id="search-input" style="width: 360px; margin-left: 16px; height: 36px; font-size: 14px; border-color: black; border-width: 1px; border-radius: 0px; margin-top: 0px;"><button style="margin-top: 0px; cursor: pointer; border-radius: 0px" value="submit" id="search-button"> Search </button>
+    </div>
+        <div style="float:right; width:100%;">
+        <a href="#" id="reset" class="govuk-link govuk-link--no-visited-state" style="float: right; font-size: 14px; margin-top: 20px;"><u> Reset search</u></a>
+        </div>
+    </div>
+        </div>
+        </form>
+
+
+        </div>
+
+
+        <style>
+        .govuk-table  {
+          box-sizing: border-box;
+          border: 1px solid #dddddd;
+          position: relative;
+          border-width: 1px;
+        }
+
+        .expandy-row {
+          border-: 1px solid;
+          box-sizing: border-box;
+          border-width: 1px;
+        }
+        </style>
+
+    <!-- My Work Table -->
+        <table  class="govuk-table my-work" style="margin-top: 0px; ">
+
+            <thead class="govuk-table__head">
+              <tr class="govuk-table__row" style="font-size:14px;background-color: rgba(199,210,193,0.5);">
+              <th class="govuk-table__header govuk-!-width-one-twelfth " scope="col"></th>
+              <th class="govuk-table__header govuk-!-width-one-sixth sortable" scope="col" id="Title" style="cursor: pointer;">Title Number</th>
+              <th class="govuk-table__header govuk-!-width-one-sixth sortable " scope="col" style="cursor: pointer;">Customer Reference</th>
+              <th class="govuk-table__header govuk-!-width-one-sixth " scope="col">Application Type</th>
+              <th class="govuk-table__header govuk-!-width-one-sixth sortable" scope="col" style="cursor: pointer;">Received by HMLR </th>
+              <th class="govuk-table__header govuk-!-width-one-sixth  " scope="col" style="width: 20%;">Application Progress</th>
+              <th class="govuk-table__header govuk-!-width-one-sixth sortable" scope="col" style="cursor: pointer;">Estimated Completion Date </th>
+              <th class="govuk-table__header govuk-!-width-one-twelfth" style="width: -4%;" scope="col">Show/hide details</th>
+              </tr>
+            </thead>
+
+
+    {% macro rows(page) %}
+              <!-- 1 -->
+          <tbody class="govuk-table__body">
+              <tr class="govuk-table__row govuk-link-table">
+                <td class="govuk-table__cell "></td>
+                <td class="govuk-table__cell " scope="row">LP123456 <p class="govuk-visually-hidden"> L927GDU </p><!-- THIS IS PAGE {{page}} --></td>
+                <td class="govuk-table__cell ">Jones.20313</td>
+                <td class="govuk-table__cell Substantive" id="">Register Update<p class="govuk-visually-hidden"> Preliminary Delayed </p></td>
+                <td class="govuk-table__cell " scope="row" data-sortable="2020-10-01">10/01/20</td>
+                <td class="govuk-table__cell " scope="row">Delayed</td>
+                <td class="govuk-table__cell " style="padding-left: 10px;"  data-sortable="2020-11-02">11/02/20</td>
+                <td class="govuk-table__cell" scope="row"><a class="expandy-row-trigger2" href="#">+</a></td>
+              </tr>
+
+
+
+          <!-- 1 Expanded row -->
+                <tr class="govuk-table__row expandy-row hide-row accordion-default-content-1" style="vertical-align: top;">
+          <!-- Vertical line -->
+                <td class="govuk-table__cell" colspan="1"></td>
+
+          <!-- HMLR reference -->
+                <div>
+                  <td class="govuk-table__cell" colspan="3">
+                    <div class="govuk-grid-row" style="margin-left: 2px;">
+                        <div class="govuk-grid-column">
+                          <b> Application progress - details</b><br> Delayed - Prior Pending Applications(s) or Official Search(es)<br><br>
+                        </div>
+                    </div>
+
+                    <div class="govuk-grid-row">
+                    </div>
+
+                    <td class="govuk-table__cell"  colspan="1" >
+                      <b> HMLR Reference</b>
+                      <p style="font-size: 14px;">L927GDU</p>
+                      </td>
+
+
+                    </tr>
+        </tbody>
+                </div>
+
+        <!-- 2 -->
+    <tbody class="govuk-table__body">
+        <tr class="govuk-table__row govuk-link-table">
+          <td class="govuk-table__cell "></td>
+          <td class="govuk-table__cell " scope="row">LP980123 <p class="govuk-visually-hidden"> LP980123 </p><!-- THIS IS PAGE {{page}} --></td>
+          <td class="govuk-table__cell ">JT/391/Williams</td>
+          <td class="govuk-table__cell Substantive" id="">New Lease<p class="govuk-visually-hidden"> Substantive Received  </p></td>
+          <td class="govuk-table__cell" scope="row" data-sortable="2020-05-01">05/01/20</td>
+          <td  class="govuk-table__cell"> <t class="govuk-tag--progress"> Received</t></td>
+          <td class="govuk-table__cell"style="padding-left: 10px;" data-sortable="2020-06-02">06/02/20</td>
+          <td class="govuk-table__cell" scope="row"><a class="expandy-row-trigger2" href="#">+</a></td>
+        </tr>
+
+    <!-- 1 Expanded row -->
+          <tr class="govuk-table__row expandy-row hide-row accordion-default-content-1" style="vertical-align: top;">
+    <!-- Vertical line -->
+          <td class="govuk-table__cell" colspan="1"></td>
+
+    <!-- HMLR reference -->
+          <div>
+            <td class="govuk-table__cell" colspan="3">
+              <div class="govuk-grid-row" style="margin-left: 2px;">
+                  <div class="govuk-grid-column">
+                    <b> Application progress - details</b><br> Received: Priority Protected - Awaiting Processing<br><br>
+                  </div>
+              </div>
+
+              <div class="govuk-grid-row">
+
+                <div class="govuk-grid-column-one-half">
+                  <b>Correspondence</b>
+                  <p style="font-size: 14px;"><br>
+                  <a href="#"> Letter issued on 22/12/19</a><br>
+                  <a class="thirdparty"> Letter issued on 24/11/19</a><br>
+                  <a href="#"> Letter issued on 12/11/19</a></p>
+                </div>
+              </div>
+
+              <td class="govuk-table__cell"  colspan="1" >
+                <b> HMLR Reference</b>
+                <p style="font-size: 14px;">S827LKJ</p>
+                </td>
+
+                <td class="govuk-table__cell" colspan="1">
+                <b> Parent Title(s)</b>
+                <p style="font-size: 14px;">	LP180123</p>
+                </td>
+              </tr>
+  </tbody>
+
+
+        <!-- 3 -->
+    <tbody class="govuk-table__body">
+        <tr class="govuk-table__row govuk-link-table">
+          <td class="govuk-table__cell "></td>
+          <td class="govuk-table__cell " scope="row">LP09209 <p class="govuk-visually-hidden"> Y917GSY </p><!-- THIS IS PAGE {{page}} --></td>
+          <td class="govuk-table__cell ">Bartlett.23124</td>
+          <td class="govuk-table__cell Substantive" id="">Official Copies<p class="govuk-visually-hidden"> Sobstantive Completed  </p></td>
+          <td class="govuk-table__cell" scope="row" data-sortable="2019-11-15">15/11/19</td>
+          <td  class="govuk-table__cell"> <t class="govuk-tag--progress">Completed</t></td>
+          <td class="govuk-table__cell"style="padding-left: 10px;" data-sortable=""</td>
+          <td class="govuk-table__cell" scope="row"><a class="expandy-row-trigger2" href="#">+</a></td>
+        </tr>
+
+        <!-- 1 Expanded row -->
+              <tr class="govuk-table__row expandy-row hide-row accordion-default-content-1" style="vertical-align: top;">
+        <!-- Vertical line -->
+              <td class="govuk-table__cell" colspan="1"></td>
+
+        <!-- HMLR reference -->
+              <div>
+                <td class="govuk-table__cell" colspan="3">
+
+
+                  <div class="govuk-grid-row">
+
+
+
+                    <div class="govuk-grid-column-one-half">
+                        <b>Files</b>
+                      <p style="font-size: 14px;"></p>
+                      <a href="#"> Official Copy of Title Plan dated 31/10/19</a><br>
+                      <a href="#">Official Copy of Register dated 31/10/19 </a><br>
+                    </div>
+
+                  </div>
+
+                  <td class="govuk-table__cell"  colspan="1" >
+                    <b> HMLR Reference</b>
+                    <p style="font-size: 14px;">Y917GSY</p>
+                    </td>
+
+
+                  </tr>
+      </tbody>
+
+
+      <!-- 4 -->
+      <tbody class="govuk-table__body">
+      <tr class="govuk-table__row govuk-link-table">
+        <td class="govuk-table__cell "></td>
+        <td class="govuk-table__cell " scope="row">LP980165 <p class="govuk-visually-hidden"> E921HSK </p><!-- THIS IS PAGE {{page}} --></td>
+        <td class="govuk-table__cell ">JT/938/Watkins	</td>
+        <td class="govuk-table__cell Substantive" id="">Official Search of Whole with Priority<p class="govuk-visually-hidden"> Sobstantive Completed  </p></td>
+        <td class="govuk-table__cell" scope="row" data-sortable="2019-11-14">14/11/19</td>
+        <td  class="govuk-table__cell"> <t class="govuk-tag--progress">Completed</t></td>
+        <td class="govuk-table__cell"style="padding-left: 10px;" data-sortable=""</td>
+        <td class="govuk-table__cell" scope="row"><a class="expandy-row-trigger2" href="#">+</a></td>
+      </tr>
+
+      <!-- 1 Expanded row -->
+            <tr class="govuk-table__row expandy-row hide-row accordion-default-content-1" style="vertical-align: top;">
+      <!-- Vertical line -->
+            <td class="govuk-table__cell" colspan="1"></td>
+
+      <!-- HMLR reference -->
+            <div>
+              <td class="govuk-table__cell" colspan="3">
+
+
+                <div class="govuk-grid-row">
+
+
+
+                  <div class="govuk-grid-column-one-half">
+                      <b>Files</b>
+                    <p style="font-size: 14px;"></p>
+                    <a href="#"> Search result dated 31/10/19</a><br>
+                    <!-- <a href="#">Official Copy of Register dated 31/10/19 </a><br> -->
+                  </div>
+
+                </div>
+
+                <td class="govuk-table__cell"  colspan="1" >
+                  <b> HMLR Reference</b>
+                  <p style="font-size: 14px;">E921HSK</p>
+                  </td>
+
+                  <td class="govuk-table__cell" colspan="1">
+                  <b> Priority period</b>
+                  <p style="font-size: 14px;">13/11/19 - 27/12/19</p>
+                  </td>
+
+
+                </tr>
+      </tbody>
+
+
+      <!-- 5 -->
+      <tbody class="govuk-table__body">
+      <tr class="govuk-table__row govuk-link-table">
+        <td class="govuk-table__cell "></td>
+        <td class="govuk-table__cell " scope="row">LP45173 <p class="govuk-visually-hidden"> M928SAI </p><!-- THIS IS PAGE {{page}} --></td>
+        <td class="govuk-table__cell ">Smith.20313	</td>
+        <td class="govuk-table__cell Substantive" id="">Transfer of Part<p class="govuk-visually-hidden"> Substantive Delayed  </p></td>
+        <td class="govuk-table__cell" scope="row" data-sortable="2019-11-13">13/11/19</td>
+        <td  class="govuk-table__cell"> <t class="govuk-tag--progress">Delayed</t></td>
+        <td class="govuk-table__cell"style="padding-left: 10px;" data-sortable="2020-01-22">22/01/20</td>
+        <td class="govuk-table__cell" scope="row"><a class="expandy-row-trigger2" href="#">+</a></td>
+      </tr>
+
+      <!-- 1 Expanded row -->
+            <tr class="govuk-table__row expandy-row hide-row accordion-default-content-1" style="vertical-align: top;">
+      <!-- Vertical line -->
+            <td class="govuk-table__cell" colspan="1"></td>
+
+      <!-- HMLR reference -->
+            <div>
+              <td class="govuk-table__cell" colspan="3">
+                <div class="govuk-grid-row" style="margin-left: 2px;">
+                    <div class="govuk-grid-column">
+                      <b> Application progress - details</b><br> Delayed - Extension of Time Granted<br><br>
+                    </div>
+                </div>
+
+                <div class="govuk-grid-row">
+
+                  <div class="govuk-grid-column-one-half">
+                    <b>Correspondence</b>
+                    <p style="font-size: 14px;"><br>
+                    <a href="#"> Requisition(s) issued on 29/11/19</a><br>
+                    <!-- <a class="thirdparty"> Notice(s) issued on 24/11/19</a><br>
+                    <a href="#"> Notice(s) issued on 12/11/19</a></p> -->
+                  </div>
+
+
+                </div>
+
+                <td class="govuk-table__cell"  colspan="1" >
+                  <b> HMLR Reference</b>
+                  <p style="font-size: 14px;">M928SAI</p>
+                  </td>
+
+
+
+                  <td class="govuk-table__cell" colspan="1">
+                  <b> Parent Title(s)</b>
+                  <p style="font-size: 14px;">LP15173</p>
+                  </td>
+                </tr>
+      </tbody>
+
+
+      <!-- 6 -->
+      <tbody class="govuk-table__body">
+      <tr class="govuk-table__row govuk-link-table">
+        <td class="govuk-table__cell "></td>
+        <td class="govuk-table__cell " scope="row">LP54312 <p class="govuk-visually-hidden"> A272JSH </p><!-- THIS IS PAGE {{page}} --></td>
+        <td class="govuk-table__cell ">Curtis.15439	</td>
+        <td class="govuk-table__cell Substantive" id="">Transfer of Part<p class="govuk-visually-hidden"> Substantive Received  </p></td>
+        <td class="govuk-table__cell" scope="row" data-sortable="2019-11-12">12/11/19</td>
+        <td  class="govuk-table__cell"> <t class="govuk-tag--progress">Received</t></td>
+        <td class="govuk-table__cell"style="padding-left: 10px;" data-sortable="2020-01-21"> 21/01/20</td>
+        <td class="govuk-table__cell" scope="row"><a class="expandy-row-trigger2" href="#">+</a></td>
+      </tr>
+
+      <!-- 1 Expanded row -->
+            <tr class="govuk-table__row expandy-row hide-row accordion-default-content-1" style="vertical-align: top;">
+      <!-- Vertical line -->
+            <td class="govuk-table__cell" colspan="1"></td>
+
+      <!-- HMLR reference -->
+            <div>
+              <td class="govuk-table__cell" colspan="3">
+                <div class="govuk-grid-row" style="margin-left: 2px;">
+                    <div class="govuk-grid-column">
+                      <b> Application progress - details</b><br> In progress<br><br>
+                    </div>
+                </div>
+
+                <div class="govuk-grid-row">
+
+
+
+
+
+                </div>
+
+                <td class="govuk-table__cell"  colspan="1" >
+                  <b> HMLR Reference</b>
+                  <p style="font-size: 14px;">A272JSH</p>
+                  </td>
+
+
+
+                  <td class="govuk-table__cell" colspan="1">
+                  <b> Parent Title(s)</b>
+                  <p style="font-size: 14px;">LP14312</p>
+                  </td>
+                </tr>
+      </tbody>
+
+      <!-- 7 -->
+      <tbody class="govuk-table__body">
+      <tr class="govuk-table__row govuk-link-table">
+        <td class="govuk-table__cell "></td>
+        <td class="govuk-table__cell " scope="row">LP980123 <p class="govuk-visually-hidden"> T832JDH </p><!-- THIS IS PAGE {{page}} --></td>
+        <td class="govuk-table__cell ">JT/722/Davis	</td>
+        <td class="govuk-table__cell Substantive" id="">Official Search of Part with Priority<p class="govuk-visually-hidden"> Sobstantive Cancelled  </p></td>
+        <td class="govuk-table__cell" scope="row" data-sortable="2019-11-10">10/11/19</td>
+        <td  class="govuk-table__cell"> <t class="govuk-tag--progress">Cancelled</t></td>
+        <td class="govuk-table__cell"style="padding-left: 10px;" data-sortable=""</td>
+        <td class="govuk-table__cell" scope="row"><a class="expandy-row-trigger2" href="#">+</a></td>
+      </tr>
+
+      <!-- 1 Expanded row -->
+            <tr class="govuk-table__row expandy-row hide-row accordion-default-content-1" style="vertical-align: top;">
+      <!-- Vertical line -->
+            <td class="govuk-table__cell" colspan="1"></td>
+
+      <!-- HMLR reference -->
+            <div>
+              <td class="govuk-table__cell" colspan="3">
+
+
+                <div class="govuk-grid-row">
+
+                  <div class="govuk-grid-column-one-half">
+                    <b>Correspondence</b>
+                    <p style="font-size: 14px;"><br>
+                    <a href="#"> Notification of Cancellation on 31/10/19</a><br>
+                    <!-- <a class="thirdparty"> Notice(s) issued on 24/11/19</a><br>
+                    <a href="#"> Notice(s) issued on 12/11/19</a></p> -->
+                  </div>
+
+                </div>
+
+                <td class="govuk-table__cell"  colspan="1" >
+                  <b> HMLR Reference</b>
+                  <p style="font-size: 14px;">T832JDH</p>
+                  </td>
+
+                  <td class="govuk-table__cell" colspan="1">
+                  <b> Priority period</b>
+                  <p style="font-size: 14px;">10/12/19 - 22/01/20</p>
+                  </td>
+
+
+                </tr>
+      </tbody>
+
+
+      <!-- 8 -->
+      <tbody class="govuk-table__body">
+      <tr class="govuk-table__row govuk-link-table">
+        <td class="govuk-table__cell "></td>
+        <td class="govuk-table__cell " scope="row"> <p class="govuk-visually-hidden"> P956EKA </p><!-- THIS IS PAGE {{page}} --></td>
+        <td class="govuk-table__cell ">Terry.43123	</td>
+        <td class="govuk-table__cell Substantive" id="">	Search of the Index Map<p class="govuk-visually-hidden"> Sobstantive Completed  </p></td>
+        <td class="govuk-table__cell" scope="row" data-sortable="2019-11-09">09/11/19</td>
+        <td  class="govuk-table__cell"> <t class="govuk-tag--progress">Completed</t></td>
+        <td class="govuk-table__cell"style="padding-left: 10px;" data-sortable=""</td>
+        <td class="govuk-table__cell" scope="row"><a class="expandy-row-trigger2" href="#">+</a></td>
+      </tr>
+
+      <!-- 1 Expanded row -->
+            <tr class="govuk-table__row expandy-row hide-row accordion-default-content-1" style="vertical-align: top;">
+      <!-- Vertical line -->
+            <td class="govuk-table__cell" colspan="1"></td>
+
+      <!-- HMLR reference -->
+            <div>
+              <td class="govuk-table__cell" colspan="3">
+
+
+                <div class="govuk-grid-row">
+
+
+
+                  <div class="govuk-grid-column-one-half">
+                      <b>Files</b>
+                    <p style="font-size: 14px;"></p>
+                    <a href="#"> Search result dated 31/11/19</a><br>
+                    <!-- <a href="#">Official Copy of Register dated 31/10/19 </a><br> -->
+                  </div>
+
+                </div>
+
+                <td class="govuk-table__cell"  colspan="1" >
+                  <b> HMLR Reference</b>
+                  <p style="font-size: 14px;">P956EKA</p>
+                  </td>
+
+
+
+
+                </tr>
+      </tbody>
+
+      <!-- 9 -->
+      <tbody class="govuk-table__body">
+      <tr class="govuk-table__row govuk-link-table">
+        <td class="govuk-table__cell "></td>
+        <td class="govuk-table__cell " scope="row">LP890543 <p class="govuk-visually-hidden"> K928TDH </p><!-- THIS IS PAGE {{page}} --></td>
+        <td class="govuk-table__cell ">Johnson.12334	</td>
+        <td class="govuk-table__cell Substantive" id="">	Register Update<p class="govuk-visually-hidden"> Preliminary Completed  </p></td>
+        <td class="govuk-table__cell" scope="row" data-sortable="2019-11-01">01/11/19</td>
+        <td  class="govuk-table__cell"> <t class="govuk-tag--progress">Completed</t></td>
+        <td class="govuk-table__cell " style="padding-left: 10px;"  data-sortable=""></td>
+        <td class="govuk-table__cell" scope="row"><a class="expandy-row-trigger2" href="#">+</a></td>
+      </tr>
+
+      <!-- 1 Expanded row -->
+            <tr class="govuk-table__row expandy-row hide-row accordion-default-content-1" style="vertical-align: top;">
+      <!-- Vertical line -->
+            <td class="govuk-table__cell" colspan="1"></td>
+
+      <!-- HMLR reference -->
+            <div>
+              <td class="govuk-table__cell" colspan="3">
+
+
+                <div class="govuk-grid-row">
+
+                  <div class="govuk-grid-column-one-half">
+                    <b>Correspondence</b>
+                    <p style="font-size: 14px;"><br>
+                    <a href="#"> Requisition(s) issued on 22/10/19</a><br>
+                    <!-- <a class="thirdparty"> Notice(s) issued on 24/11/19</a><br>
+                    <a href="#"> Notice(s) issued on 12/11/19</a></p> -->
+                  </div>
+
+                  <div class="govuk-grid-column-one-half">
+                      <b>Files</b>
+                    <p style="font-size: 14px;"></p>
+                    <a href="#"> Official Copy of Register dated 31/10/19</a><br>
+                    <!-- <a href="#">Official Copy of Register dated 31/10/19 </a><br> -->
+                  </div>
+
+                </div>
+
+                <td class="govuk-table__cell"  colspan="1" >
+                  <b> HMLR Reference</b>
+                  <p style="font-size: 14px;">K928TDH</p>
+                  </td>
+
+
+                </tr>
+      </tbody>
+
+      <!-- 10 -->
+      <tbody class="govuk-table__body">
+      <tr class="govuk-table__row govuk-link-table">
+        <td class="govuk-table__cell "></td>
+        <td class="govuk-table__cell " scope="row">LP980123 <p class="govuk-visually-hidden"> A391OLS </p><!-- THIS IS PAGE {{page}} --></td>
+        <td class="govuk-table__cell ">JT/103/Wilson	</td>
+        <td class="govuk-table__cell Substantive" id="">	New Lease<p class="govuk-visually-hidden"> Substantive Completed  </p></td>
+        <td class="govuk-table__cell" scope="row" data-sortable="2019-01-11">01/11/19</td>
+        <td  class="govuk-table__cell"> <t class="govuk-tag--progress">Completed</t></td>
+        <td class="govuk-table__cell " style="padding-left: 10px;"  data-sortable="1"></td>
+        <!-- <td class="govuk-table__cell"style="padding-left: 10px;" data-sortable=""</td> -->
+        <td class="govuk-table__cell" scope="row"><a class="expandy-row-trigger2" href="#">+</a></td>
+      </tr>
+
+      <!-- 1 Expanded row -->
+            <tr class="govuk-table__row expandy-row hide-row accordion-default-content-1" style="vertical-align: top;">
+      <!-- Vertical line -->
+            <td class="govuk-table__cell" colspan="1"></td>
+
+      <!-- HMLR reference -->
+            <div>
+              <td class="govuk-table__cell" colspan="3">
+
+
+                <div class="govuk-grid-row">
+
+
+
+                  <div class="govuk-grid-column-one-half">
+                      <b>Files</b>
+                    <p style="font-size: 14px;"></p>
+                    <a href="#"> Registration Completion Sheet dated 31/10/19</a><br>
+                    <a href="#">Official Copy of Register dated 31/10/19 </a><br>
+                    <a href="#">Official Copy of Title Plan dated 31/10/19 </a><br>
+                  </div>
+
+                </div>
+
+                <td class="govuk-table__cell"  colspan="1" >
+                  <b> HMLR Reference</b>
+                  <p style="font-size: 14px;">A391OLS</p>
+                  </td>
+
+                  <td class="govuk-table__cell" colspan="1">
+                  <b> Parent Title(s)</b>
+                  <p style="font-size: 14px;">LP180123</p>
+                  </td>
+
+
+                </tr>
+      </tbody>
+
+
+          </div>
+
+
+      </tbody>
+
+
+
+    {% endmacro %}
+
+    {{rows(1)}}
+    {# {{rows(2)}}
+    {{rows(3)}}
+    {{rows(4)}}
+    {{rows(5)}} #}
+
+    </table>
+
+    <div class="govuk-grid-column-one-quarter" style="float: right; text-align: right;">
+
+
+
+      <div style="margin-left: -1000px;"><p style="font-size: 16px;"> Displaying 1 - 10 of 20 applications</p></div>
+    <div id="pagination"><p style="font-size: 16px;"> 1 <a style="font-size: 16px;" href="#">2</a> <a style="font-size: 16px;" href="#">></a> </p></div>
+    </div>
+
+                    
+
+      </div>
+
+
+<style>
+
+.details {
+  text-decoration: underline;
+}
+
+.govuk-details {
+  font-size: 16px;
+  max-width: 600px;
+
+}
+
+</style>
+
+<!---CONTENT----------------------------------------------------------------->
+
+
+
+
+
+<!-- </footer> -->
+<div class="govuk-grid-row">
+<div class="footer-link">
+<div class="govuk-grid-column-full" id="headerdiv">
+<div class="govuk-width-container">
+    <br>
+    <br>
+    <hr style="height: 4px;  background-image: linear-gradient(-60deg,#b4d307,#b4d307 50%,#d7e900 0,#d7e900); border: none;">
+
+
+
+<br>
+<a class="footlink" style="text-color: grey; text-decoration: none;"><u>Terms and conditions</u></a>
+<a>|</a>
+<a class="footlink" style="text-color: grey; text-decoration: none;"><u>Accessibility Statement</u></a>
+<a>|</a>
+<a class="footlink" style="text-color: grey; text-decoration: none;"><u>Freedom of information</u></a>
+<a>|</a>
+<a class="footlink" style="text-color: grey; text-decoration: none;"><u>© Crown copyright</u></a>
+
+<a style="float:right;" href="/prototype-admin/clear-data"> Clear data </a>
+<br>
+<br>
+<a class="footlink-no" style="text-color: grey; text-decoration: none;"><i>These links will open in a new window.</i></a>
+<p></p>
+</div>
+</div>
+</div>
+</div>
+
+
+
+
+
+
+
+{% endblock %}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -276,7 +276,8 @@
                       <li>New layout inspired more by GOV UK with visible filters and search - <a href="Sprint_25_V3.html">View</a> </li>
                       <li>New layout inspired by GOV UK with hidden filters and search - <a href="Sprint_25_V4.html">View</a> </li>
                       <li>Existing VMA design but with thicker titles - <a href="Sprint_25_V5.html">View</a> </li>
-                  </ul>
+                      <li>Existing VMA design but navigation menu at the top - <a href="Sprint_25_V6.html">View</a> </li>
+                    </ul>
                 </div>
               </div>
              


### PR DESCRIPTION
This update removes the left navigation menu and updates it with menu titles based on UR. This also allows for the table of data to fit full width.

![image](https://user-images.githubusercontent.com/64266608/95063075-c3ffaf80-06f5-11eb-8821-a3c7e20b59b2.png)
